### PR TITLE
:bricks: `decode_remove_friend` 返回类型更改为 `RQResult<DelFriendResponse>`

### DIFF
--- a/rq-engine/src/command/friendlist/decoder.rs
+++ b/rq-engine/src/command/friendlist/decoder.rs
@@ -110,7 +110,7 @@ impl super::super::super::Engine {
     }
 
     //friendlist.delFriend
-    pub fn decode_remove_friend(&self, mut payload: Bytes) -> RQResult<()> {
+    pub fn decode_remove_friend(&self, mut payload: Bytes) -> RQResult<DelFriendResponse> {
         let mut req: jce::RequestPacket = jcers::from_buf(&mut payload)?;
 
         let mut data: jce::RequestDataVersion3 = jcers::from_buf(&mut req.s_buffer)?;
@@ -120,13 +120,6 @@ impl super::super::super::Engine {
         ))?;
         let resp = jcers::from_buf::<_, jce::DelFriendResp>(&mut r).map_err(RQError::Jce)?;
 
-        if resp.error_code != 0 {
-            Ok(())
-        } else {
-            Err(RQError::Other(format!(
-                "Delete Friend Failure : code = {}",
-                resp.error_code
-            )))
-        }
+        Ok(DelFriendResponse { err_code: resp.error_code })
     }
 }

--- a/rq-engine/src/command/friendlist/mod.rs
+++ b/rq-engine/src/command/friendlist/mod.rs
@@ -22,3 +22,8 @@ pub struct GroupMemberListResponse {
     pub next_uin: i64,
     pub list: Vec<GroupMemberInfo>,
 }
+
+#[derive(Debug)]
+pub struct DelFriendResponse{
+    pub err_code:i16
+}


### PR DESCRIPTION
将error_code判断移动到api中完成

需要等待 `build-friendlist.DelFriend` 完成合并后才可更改api 部分接口