### PR TITLE
image size

### DIFF
--- a/rq-engine/src/msg/elem/group_image.rs
+++ b/rq-engine/src/msg/elem/group_image.rs
@@ -13,6 +13,7 @@ pub struct GroupImage {
     pub height: i32,
     pub md5: Vec<u8>,
     pub orig_url: Option<String>,
+    pub image_type: i32,
 }
 
 impl GroupImage {

--- a/rs-qq/Cargo.toml
+++ b/rs-qq/Cargo.toml
@@ -21,6 +21,6 @@ chrono = "0.4"
 derivative = "2"
 jcers = { version = "0.1", features = ["derive"] }
 rq-engine = { path = "../rq-engine" }
-
+image = { version = "0", features = ["png", "jpeg", "bmp", "gif", "webp"] }
 
 

--- a/rs-qq/src/client/api.rs
+++ b/rs-qq/src/client/api.rs
@@ -1130,14 +1130,21 @@ impl super::Client {
         let req = self
             .get_group_image_store(group_code, file_name, image_md5.clone(), image_size)
             .await?;
+        let image_data = match image::load_from_memory(&image) {
+            Ok(image) => image,
+            Err(err) => {
+                return RQResult::Err(RQError::Other(format!("image data error : {:?}", err)))
+            }
+        };
+        let width = image_data.width() as i32;
+        let height = image_data.height() as i32;
         match req {
             GroupImageStoreResp::Exist { file_id } => Ok(GroupImage {
                 image_id: calculate_image_resource_id(&image_md5, false),
                 file_id: file_id as i64,
                 size: image_size,
-                // TODO width, height
-                width: 720 as i32,
-                height: 480 as i32,
+                width,
+                height,
                 md5: image_md5,
                 ..Default::default()
             }),
@@ -1164,14 +1171,13 @@ impl super::Client {
                     },
                 )
                 .await?;
-                // TODO width, height
                 // TODO image_type
                 Ok(GroupImage {
                     image_id: calculate_image_resource_id(&image_md5, false),
                     file_id: file_id as i64,
                     size: image_size,
-                    width: 720,
-                    height: 480,
+                    width,
+                    height,
                     md5: image_md5,
                     ..Default::default()
                 })

--- a/rs-qq/src/client/api.rs
+++ b/rs-qq/src/client/api.rs
@@ -1138,6 +1138,14 @@ impl super::Client {
         };
         let width = image_data.width() as i32;
         let height = image_data.height() as i32;
+        let image_type = if image.get(0).unwrap() == 47
+            && image.get(0).unwrap() == 49
+            && image.get(0).unwrap() == 46
+        {
+            2000
+        } else {
+            1000
+        };
         match req {
             GroupImageStoreResp::Exist { file_id } => Ok(GroupImage {
                 image_id: calculate_image_resource_id(&image_md5, false),
@@ -1146,6 +1154,7 @@ impl super::Client {
                 width,
                 height,
                 md5: image_md5,
+                image_type,
                 ..Default::default()
             }),
             GroupImageStoreResp::NotExist {
@@ -1171,7 +1180,6 @@ impl super::Client {
                     },
                 )
                 .await?;
-                // TODO image_type
                 Ok(GroupImage {
                     image_id: calculate_image_resource_id(&image_md5, false),
                     file_id: file_id as i64,
@@ -1179,6 +1187,7 @@ impl super::Client {
                     width,
                     height,
                     md5: image_md5,
+                    image_type,
                     ..Default::default()
                 })
             }


### PR DESCRIPTION
用了image库获取了图片的大小，用前几个字节获取了图片类型。

- 这是不科学的, 因为读取整个图片消耗内存很多, 或许我们应该从文件的前几个字节获取图片的 thpe / width / height.



