### PR TITLE
custom online status

### DIFF
--- a/examples/password_login/src/main.rs
+++ b/examples/password_login/src/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use rs_qq::device::Device;
 use rs_qq::ext::common::after_login;
 use rs_qq::handler::DefaultHandler;
-use rs_qq::structs::UserOnlineStatus;
+use rs_qq::structs::{CustomStatus, UserOnlineStatus};
 use rs_qq::version::{get_version, Protocol};
 use rs_qq::{Client, LoginDeviceLocked, LoginNeedCaptcha, LoginSuccess};
 use rs_qq::{LoginResponse, LoginUnknownStatus};
@@ -170,7 +170,13 @@ async fn main() -> Result<()> {
     // chain.push(group_image);
     // client.send_group_message(982166018, chain).await.ok();
     client
-        .update_online_status(UserOnlineStatus::Qme)
+        .update_online_status(
+            UserOnlineStatus::Qme,
+            CustomStatus {
+                face_index: 100,
+                words: "棒棒".to_owned(),
+            },
+        )
         .await
         .ok();
 

--- a/examples/password_login/src/main.rs
+++ b/examples/password_login/src/main.rs
@@ -172,10 +172,10 @@ async fn main() -> Result<()> {
     client
         .update_online_status(
             UserOnlineStatus::Qme,
-            CustomStatus {
+            Some(CustomStatus {
                 face_index: 100,
-                words: "棒棒".to_owned(),
-            },
+                words: "棒棒1".to_owned(),
+            }),
         )
         .await
         .ok();

--- a/rq-engine/src/command/stat_svc/builder.rs
+++ b/rq-engine/src/command/stat_svc/builder.rs
@@ -40,16 +40,14 @@ impl super::super::super::Engine {
             vendor_os_name: transport.device.vendor_os_name.to_owned(),
             ext_online_status,
             timestamp: chrono::Utc::now().timestamp(),
-            custom_status: if let Some(custom_status) = custom_status {
-                crate::pb::online_status::CustomStatus {
+            custom_status: custom_status
+                .map(|custom_status| crate::pb::online_status::CustomStatus {
                     uface_index: Some(custom_status.face_index),
                     s_wording: Some(custom_status.words),
                     uface_type: Some(1),
-                }
-                .to_bytes()
-            } else {
-                Bytes::default()
-            },
+                })
+                .unwrap_or_default()
+                .to_bytes(),
             ..Default::default()
         };
         let pkt = self.svc_req_register_pkt(svc);

--- a/rq-engine/src/command/stat_svc/builder.rs
+++ b/rq-engine/src/command/stat_svc/builder.rs
@@ -41,7 +41,7 @@ impl super::super::super::Engine {
             ext_online_status,
             timestamp: chrono::Utc::now().timestamp(),
             custom_status: if let Some(custom_status) = custom_status {
-                crate::pb::onlinestatus::CustomStatus {
+                crate::pb::online_status::CustomStatus {
                     uface_index: Some(custom_status.face_index),
                     s_wording: Some(custom_status.words),
                     uface_type: Some(1),

--- a/rq-engine/src/pb/mod.rs
+++ b/rq-engine/src/pb/mod.rs
@@ -38,8 +38,8 @@ pub mod oidb {
     include!(concat!(env!("OUT_DIR"), "/oidb.rs"));
 }
 
-pub mod onlinestatus {
-    include!(concat!(env!("OUT_DIR"), "/onlinestatus.rs"));
+pub mod online_status {
+    include!(concat!(env!("OUT_DIR"), "/online_status.rs"));
 }
 
 pub mod profilecard {

--- a/rq-engine/src/pb/mod.rs
+++ b/rq-engine/src/pb/mod.rs
@@ -38,6 +38,10 @@ pub mod oidb {
     include!(concat!(env!("OUT_DIR"), "/oidb.rs"));
 }
 
+pub mod onlinestatus {
+    include!(concat!(env!("OUT_DIR"), "/onlinestatus.rs"));
+}
+
 pub mod profilecard {
     include!(concat!(env!("OUT_DIR"), "/profilecard.rs"));
 }

--- a/rq-engine/src/pb/onlinestatus/custom_status.proto
+++ b/rq-engine/src/pb/onlinestatus/custom_status.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+package onlinestatus;
+
+message CustomStatus {
+  optional uint64 ufaceIndex = 1;
+  optional string sWording = 2;
+  optional uint64 ufaceType = 3;
+}
+

--- a/rq-engine/src/pb/onlinestatus/custom_status.proto
+++ b/rq-engine/src/pb/onlinestatus/custom_status.proto
@@ -1,5 +1,5 @@
 syntax = "proto2";
-package onlinestatus;
+package online_status;
 
 message CustomStatus {
   optional uint64 ufaceIndex = 1;

--- a/rq-engine/src/structs.rs
+++ b/rq-engine/src/structs.rs
@@ -211,7 +211,7 @@ pub struct MessageReceipt {
     pub time: i64,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum UserOnlineStatus {
     Online = 11,          // 在线
     Offline = 21,         // 离线
@@ -239,4 +239,10 @@ pub enum UserOnlineStatus {
     Vacationing = 1022,   // 度假中
     WatchingTV = 1021,    // 追剧中
     Fitness = 1020,       // 健身中
+}
+
+#[derive(Debug, Clone)]
+pub struct CustomStatus {
+    pub face_index: u64,
+    pub words: String,
 }

--- a/rs-qq/src/client/api.rs
+++ b/rs-qq/src/client/api.rs
@@ -16,7 +16,7 @@ use rq_engine::msg::elem::{calculate_image_resource_id, Anonymous, FriendImage, 
 use rq_engine::msg::MessageChain;
 use rq_engine::pb;
 use rq_engine::protocol::device::random_string;
-use rq_engine::structs::UserOnlineStatus;
+use rq_engine::structs::{CustomStatus, UserOnlineStatus};
 
 use crate::client::Group;
 use crate::engine::command::{friendlist::*, oidb_svc::*, profile_service::*, wtlogin::*};
@@ -183,18 +183,39 @@ impl super::Client {
 
 /// API
 impl super::Client {
-    /// 设置在线状态 TODO net_type, custom_status
-    pub async fn update_online_status(&self, status: UserOnlineStatus) -> RQResult<()> {
-        let (status, ext_status) = if (status as i32) < 1000 {
+    /// 设置在线状态 TODO net_type
+    pub async fn update_online_status<T>(
+        &self,
+        status: UserOnlineStatus,
+        custom_status: T,
+    ) -> RQResult<()>
+    where
+        T: Into<Option<CustomStatus>>,
+    {
+        let custom_status = custom_status.into();
+        let (status, ext_status) = if custom_status.is_some() {
+            let words = &custom_status.as_ref().unwrap().words;
+            if words.is_empty() {
+                return RQResult::Err(RQError::Other(
+                    "Custom status words must not be empty".to_owned(),
+                ));
+            }
+            if words.chars().count() > 4 {
+                return RQResult::Err(RQError::Other(
+                    "Custom status words len cannot be greater than 4".to_owned(),
+                ));
+            }
+            (11, 2000)
+        } else if (status as i32) < 1000 {
             (status as i32, 0)
         } else {
             (11, status as i64)
         };
-        let req = self
-            .engine
-            .read()
-            .await
-            .build_set_online_status_packet(status, ext_status);
+        let req = self.engine.read().await.build_set_online_status_packet(
+            status,
+            ext_status,
+            custom_status,
+        );
         let _ = self.send_and_wait(req).await?;
         Ok(())
     }


### PR DESCRIPTION
对 update_online_status 追加了一个参数custom_status, 可以为None, 也可以为Some(CustomStatus), 也可以为CustomStatus。

   custom_status 不为空时校验文字是否为1-4个字符, 以保证数据正确。并将extStatus设置成2000, 以应用Diy Custom Info。

   custom_status 为空时, 按照之前的流程设置状态。
